### PR TITLE
Release 5.0.0.dev1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,12 @@ Changelog
 =========
 
 Unreleased
+==========
+
+
+5.0.0.dev1 (2021-12-14)
 ==================
+
 * feat: Exposed the setting DJANGOCMS_SNIPPET_VERSIONING_MIGRATION_USER_ID as an environment variable for the Divio addon
 * fix: Error when rendering a Draft Snippet plugin on a Published page
 * fix: Publish snippets by default as they were already in that state pre-versioning and cleanup unnecessary migration files before release!

--- a/djangocms_snippet/__init__.py
+++ b/djangocms_snippet/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '3.0.0'
+__version__ = '5.0.0.dev1'
 
 default_app_config = 'djangocms_snippet.apps.SnippetConfig'


### PR DESCRIPTION
## Description

This is the first django cms v4 compatible version integrated with djangocms-versioning. It is a development release that will not be pushed to Pypi and will only be released as a Divio addon initially. The release number 5.0.0 leaves 4.0.0 for the next major django version. 