### PR TITLE
fix: django-cms 4.0.x - Remove breaking django-treebeard pinning issue

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,10 +4,11 @@ Changelog
 
 Unreleased
 ==========
+* fix: Removed tight django-treebeard restriction added when 4.5.0 contained breaking changes. The core CMS and django-treebeard have since been patched to resolve the issue.
 
 
 4.0.0.dev1 (2021-12-14)
-==================
+=======================
 
 * feat: Exposed the setting DJANGOCMS_SNIPPET_VERSIONING_MIGRATION_USER_ID as an environment variable for the Divio addon
 * fix: Error when rendering a Draft Snippet plugin on a Published page

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from djangocms_snippet import __version__
 
 REQUIREMENTS = [
     'django-cms',
-    'django-treebeard>=4.3,<4.5',
+    'django-treebeard>=4.3',
 ]
 
 


### PR DESCRIPTION
## Description

This change removes an old issue protecting broken changes in django-treebeard 4.5.0 where the core CMS and treebeard has since received patches.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* Issue introduced in 4.5: https://github.com/django-treebeard/django-treebeard/blob/master/CHANGES.md#release-45-feb-17-2021
* Resolved in 4.5.1: https://github.com/django-treebeard/django-treebeard/blob/master/CHANGES.md#release-451-feb-22-2021


## Checklist

* [x] I have opened this pull request against ``support/django-cms-4.0.x``
* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
