### PR TITLE
feat: Removing slug field from list display when versioning is enabled

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Changelog
 Unreleased
 ==========
 
+* fix: Slug field on list display for admin should only be displayed when versioning is not available
 
 4.0.0.dev2 (2021-12-22)
 =======================

--- a/djangocms_snippet/admin.py
+++ b/djangocms_snippet/admin.py
@@ -26,9 +26,8 @@ except ImportError:
 
 
 class SnippetAdmin(*snippet_admin_classes):
-    list_display = ('slug', 'name')
-    search_fields = ['slug', 'name']
-    prepopulated_fields = {'slug': ('name',)}
+    list_display = ('name',)
+    search_fields = ['name']
     change_form_template = 'djangocms_snippet/admin/change_form.html'
     text_area_attrs = {
         'rows': 20,
@@ -45,6 +44,24 @@ class SnippetAdmin(*snippet_admin_classes):
 
     class Meta:
         model = Snippet
+
+    def get_list_display(self, request):
+        list_display = super().get_list_display(request)
+        if not djangocms_versioning_enabled:
+            list_display.append('slug')
+        return list_display
+
+    def get_search_fields(self, request):
+        search_fields = super().get_search_fields(request)
+        if not djangocms_versioning_enabled:
+            search_fields.append('slug')
+        return search_fields
+
+    def get_prepopulated_fields(self, request):
+        prepopulated_fields = super().get_prepopulated_fields(request)
+        if not djangocms_versioning_enabled:
+            prepopulated_fields = {'slug': ('name',)}
+        return prepopulated_fields
 
     def get_urls(self):
         info = self.model._meta.app_label, self.model._meta.model_name

--- a/djangocms_snippet/admin.py
+++ b/djangocms_snippet/admin.py
@@ -47,8 +47,11 @@ class SnippetAdmin(*snippet_admin_classes):
 
     def get_list_display(self, request):
         list_display = super().get_list_display(request)
+        list_display = list(list_display)
+
         if not djangocms_versioning_enabled:
-            list_display.append('slug')
+            list_display.insert(0, 'slug')
+            list_display = tuple(list_display)
         return list_display
 
     def get_search_fields(self, request):

--- a/djangocms_snippet/admin.py
+++ b/djangocms_snippet/admin.py
@@ -57,7 +57,7 @@ class SnippetAdmin(*snippet_admin_classes):
             search_fields.append('slug')
         return search_fields
 
-    def get_prepopulated_fields(self, request):
+    def get_prepopulated_fields(self, obj, request):
         prepopulated_fields = super().get_prepopulated_fields(request)
         if not djangocms_versioning_enabled:
             prepopulated_fields = {'slug': ('name',)}

--- a/djangocms_snippet/admin.py
+++ b/djangocms_snippet/admin.py
@@ -18,11 +18,10 @@ djangocms_versioning_enabled = SnippetCMSAppConfig.djangocms_versioning_enabled
 
 try:
     from djangocms_versioning.admin import ExtendedVersionAdminMixin
-
     if djangocms_versioning_enabled:
         snippet_admin_classes.insert(0, ExtendedVersionAdminMixin)
 except ImportError:
-    pass
+    djangocms_versioning_enabled = False
 
 
 class SnippetAdmin(*snippet_admin_classes):
@@ -51,7 +50,8 @@ class SnippetAdmin(*snippet_admin_classes):
 
         if not djangocms_versioning_enabled:
             list_display.insert(0, 'slug')
-            list_display = tuple(list_display)
+
+        list_display = tuple(list_display)
         return list_display
 
     def get_search_fields(self, request):

--- a/djangocms_snippet/admin.py
+++ b/djangocms_snippet/admin.py
@@ -66,6 +66,13 @@ class SnippetAdmin(*snippet_admin_classes):
             prepopulated_fields = {'slug': ('name',)}
         return prepopulated_fields
 
+    def get_list_display_links(self, request, list_display):
+        if not djangocms_versioning_enabled:
+            return list(list_display)[:1]
+        else:
+            self.list_display_links = (None,)
+            return self.list_display_links
+
     def get_urls(self):
         info = self.model._meta.app_label, self.model._meta.model_name
         return [

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -179,3 +179,33 @@ class SnippetAdminFormTestCase(CMSTestCase):
         self.assertContains(response, '<div class="readonly">Test Snippet</div>')
         # We should have the same number of snippets as before
         self.assertEqual(Snippet.objects.count(), 1)
+
+    @override_settings(DJANGOCMS_SNIPPET_VERSIONING_ENABLED=False)
+    def test_slug_colomn_should_hyperlinked_with_versioning_disabled(self):
+        """
+        Slug column should be visible and hyperlinked when versioning is disabled
+        """
+        admin.site.unregister(Snippet)
+        reload(cms_config)
+        reload(snippet_admin)
+
+        with self.login_user_context(self.get_superuser()):
+            response = self.client.get(self.changelist_url)
+        self.assertContains(response, '<th class="field-slug"><a href="/en/admin/djangocms_snippet/'
+                                      'snippet/1/change/">test-snippet</a></th>')
+
+    @override_settings(DJANGOCMS_SNIPPET_VERSIONING_ENABLED=True)
+    def test_name_colomn_should_not_be_hyperlinked_with_versioning_enabled(self):
+        """
+        Name column should be visible and not hyperlinked when versioning is enabled.
+        Slug column should not be visible when versioning is enabled.
+        """
+        admin.site.unregister(Snippet)
+        reload(cms_config)
+        reload(snippet_admin)
+
+        with self.login_user_context(self.get_superuser()):
+            response = self.client.get(self.changelist_url)
+        self.assertContains(response, '<td class="field-name">Test Snippet</td>')
+        self.assertNotContains(response, '<th class="field-slug"><a href="/en/admin/djangocms_snippet/'
+                                         'snippet/1/change/">test-snippet</a></th>')

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -59,7 +59,7 @@ class SnippetAdminTestCase(CMSTestCase):
             self.snippet_admin.__class__.__bases__, (ExtendedVersionAdminMixin, admin.ModelAdmin)
         )
         self.assertEqual(
-            list_display[:-1], ('slug', 'name', 'get_author', 'get_modified_date', 'get_versioning_state')
+            list_display[:-1], ('name', 'get_author', 'get_modified_date', 'get_versioning_state')
         )
         self.assertEqual(list_display[-1].short_description, 'actions')
         self.assertIn("function ExtendedVersionAdminMixin._list_actions", list_display[-1].__str__())


### PR DESCRIPTION
## Description

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->
Slug field for list display in admin should only be visible when versioning is not enabled.

By default behaviour, the first column ('Name' after removal of 'slug') gets hyperlinked to the change function. The following action needs to be taken:
When versioning is enabled
* Remove the slug column
* Remove hyperlink from the Name column

**Versioning Enabled**

![image](https://user-images.githubusercontent.com/18738275/148394839-bc2d3ded-61d1-471c-8635-7f5e7a39c939.png)

**Versioning Disabled**

![image](https://user-images.githubusercontent.com/18738275/148395112-4d518aa1-bf71-4cc8-bbc4-2f70034f4fee.png)

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``master``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
