### PR TITLE
fix: Snippet plugin showing ID instead of name

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Changelog
 Unreleased
 ==========
 
+* fix: Snippet plugin added to a page now displays name instead of ID
 
 4.0.0.dev2 (2021-12-22)
 =======================

--- a/djangocms_snippet/models.py
+++ b/djangocms_snippet/models.py
@@ -106,6 +106,10 @@ class SnippetPtr(CMSPlugin):
 
     search_fields = ['snippet__html'] if SEARCH_ENABLED else []
 
+    def get_short_description(self):
+        snippet_label = SnippetGrouper.objects.filter(pk=self.snippet_grouper.pk).first()
+        return snippet_label
+
     class Meta:
         verbose_name = _('Snippet Ptr')
         verbose_name_plural = _('Snippet Ptrs')

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -3,7 +3,7 @@ import datetime
 from cms.api import add_plugin, create_page
 from cms.models import PageContent
 from cms.test_utils.testcases import CMSTestCase
-from cms.toolbar.utils import get_object_edit_url
+from cms.toolbar.utils import get_object_edit_url, get_object_structure_url
 
 from djangocms_snippet.models import Snippet, SnippetGrouper
 from djangocms_versioning.models import Version
@@ -290,3 +290,21 @@ class SnippetPluginVersioningRenderTestCase(CMSTestCase):
 
         self.assertContains(response, "<p>Published snippet</p>")
         self.assertNotIn("Draft snippet", str(response.content))
+
+    def test_correct_name_is_displayed_for_snippet_component_on_page(self):
+        """
+        If a component is added to the page, it should show the snippet name and not ID
+        """
+        add_plugin(
+            self.draft_pagecontent.placeholders.get(slot="content"),
+            "SnippetPlugin",
+            self.language,
+            snippet_grouper=self.draft_snippet.snippet_grouper,
+        )
+
+        # Request structure endpoint on page
+        request_url = get_object_structure_url(self.draft_pagecontent, "en")
+        with self.login_user_context(self.superuser):
+            response = self.client.get(request_url)
+
+        self.assertContains(response, "<strong>Snippet</strong> plugin_snippet</span>")


### PR DESCRIPTION
## Description

When adding a snippet using the snippets component on the page, a snippet ID is visible instead of the snippet name

This fix resolves the issue where the snippet name/description is displayed.

![image](https://user-images.githubusercontent.com/18738275/148561087-4b8d4db1-3a81-45c6-be03-cf126caaafea.png)

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``master``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
