### PR TITLE
Fix: Removed unnecessary template contents, to decrease unused content…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 
 Unreleased
 ==========
+* fix: Removed unused contents within templates, reducing the clutter within version compare views.
 
 
 4.0.0.dev2 (2021-12-22)

--- a/djangocms_snippet/templates/djangocms_snippet/admin/preview.html
+++ b/djangocms_snippet/templates/djangocms_snippet/admin/preview.html
@@ -1,18 +1,1 @@
-{% extends "admin/base_site.html" %}
-{% load static  %}
 {{ snippet.html|safe|escape }}
-
-{% block extrastyle %}
-  {{ block.super }}
-  <link rel="stylesheet" type="text/css" href="{% static "admin/css/changelists.css" %}">
-{% endblock %}
-
-{% block coltype %}flex{% endblock %}
-
-{% block bodyclass %}{{ block.super }} app-{{ opts.app_label }} model-{{ opts.model_name }} change-list{% endblock %}
-
-{% block content %}
-    {% autoescape off %}
-        {{ snippet.html }}
-    {% endautoescape %}
-{% endblock %}


### PR DESCRIPTION
## Description
This PR covers removing unecessary snippet template contents, such as extending the admin base. Previously this was causing a lot of junk to be included in the version comparison, this will now be reduced.
<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources
* Introduced as part of versioning changes here: https://github.com/django-cms/djangocms-snippet/commit/e215e01be429e6fd24a6e97233ead2ccc497ee62#diff-10ca2c498cfc989bd13ff753d74cd304329b377e63def3ad2d12c4cb0b2f89be

Before
<img width="1787" alt="Screenshot 2022-01-07 at 16 57 50" src="https://user-images.githubusercontent.com/5971953/148578892-442fb620-65e6-4bfe-980f-8decb7f5923b.png">


After
<img width="1772" alt="Screenshot 2022-01-07 at 16 56 16" src="https://user-images.githubusercontent.com/5971953/148578671-b3232e99-da7d-4201-932e-6313a177861f.png">


## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``support/django-cms-4.0.x``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
