### PR TITLE
Release 4.0.0.dev3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,11 @@ Changelog
 
 Unreleased
 ==========
+
+
+4.0.0.dev2 (2021-12-22)
+=======================
+
 * fix: Removed tight django-treebeard restriction added when 4.5.0 contained breaking changes. The core CMS and django-treebeard have since been patched to resolve the issue.
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,7 +11,7 @@ Unreleased
 
 * fix: Snippet plugin added to a page now displays name instead of ID
 * fix: Slug field on list display for admin should only be displayed when versioning is not available
-* fix: fix: Removed unused contents within templates, reducing the clutter within version compare views. Previously this was causing a lot of junk to be included in the version comparison, this will now be reduced.
+* fix: Removed unused contents within templates, reducing the clutter within version compare views. Previously this was causing a lot of junk to be included in the version comparison, this will now be reduced.
 
 
 4.0.0.dev2 (2021-12-22)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ Unreleased
 * fix: Snippet plugin added to a page now displays name instead of ID
 * fix: Slug field on list display for admin should only be displayed when versioning is not available
 
+
 4.0.0.dev2 (2021-12-22)
 =======================
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,9 @@ Changelog
 Unreleased
 ==========
 
+4.0.0.dev3 (2022-01-11)
+=======================
+
 * fix: Snippet plugin added to a page now displays name instead of ID
 * fix: Slug field on list display for admin should only be displayed when versioning is not available
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,14 +4,15 @@ Changelog
 
 Unreleased
 ==========
-* fix: Removed unused contents within templates, reducing the clutter within version compare views.
+
 
 4.0.0.dev3 (2022-01-11)
 =======================
 
 * fix: Snippet plugin added to a page now displays name instead of ID
 * fix: Slug field on list display for admin should only be displayed when versioning is not available
-* fix: Removed unnecessary snippet template contents, such as extending the admin base. Previously this was causing a lot of junk to be included in the version comparison, this will now be reduced.
+* fix: fix: Removed unused contents within templates, reducing the clutter within version compare views. Previously this was causing a lot of junk to be included in the version comparison, this will now be reduced.
+
 
 4.0.0.dev2 (2021-12-22)
 =======================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ Unreleased
 
 * fix: Snippet plugin added to a page now displays name instead of ID
 * fix: Slug field on list display for admin should only be displayed when versioning is not available
-
+* fix: Removed unnecessary snippet template contents, such as extending the admin base. Previously this was causing a lot of junk to be included in the version comparison, this will now be reduced.
 
 4.0.0.dev2 (2021-12-22)
 =======================

--- a/djangocms_snippet/__init__.py
+++ b/djangocms_snippet/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '4.0.0.dev2'
+__version__ = '4.0.0.dev3'
 
 default_app_config = 'djangocms_snippet.apps.SnippetConfig'

--- a/djangocms_snippet/__init__.py
+++ b/djangocms_snippet/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '4.0.0.dev1'
+__version__ = '4.0.0.dev2'
 
 default_app_config = 'djangocms_snippet.apps.SnippetConfig'


### PR DESCRIPTION
## Description

- Snippet plugin added to a page now displays name instead of ID
- Slug field on list display for admin should only be displayed when versioning is not available
- Removed unnecessary snippet template contents, such as extending the admin base. Previously this was causing a lot of junk to be included in the version comparison, this will now be reduced.

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``master``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
