### PR TITLE
Update readme badges

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 django CMS Snippet
 ==================
 
-|pypi| |build| |coverage|
+|pypi| |coverage| |python| |django| |djangocms|
 
 
 **django CMS Snippet** provides a plugin for `django CMS <http://django-cms.org>`_
@@ -30,8 +30,8 @@ Contribute to this project and win rewards
 
 Because this is a an open-source project, we welcome everyone to
 `get involved in the project <https://www.django-cms.org/en/contribute/>`_ and
-`receive a reward <https://www.django-cms.org/en/bounty-program/>`_ for their contribution. 
-Become part of a fantastic community and help us make django CMS the best CMS in the world.   
+`receive a reward <https://www.django-cms.org/en/bounty-program/>`_ for their contribution.
+Become part of a fantastic community and help us make django CMS the best CMS in the world.
 
 We'll be delighted to receive your
 feedback in the form of issues and pull requests. Before submitting your
@@ -50,9 +50,7 @@ Documentation
 =============
 
 See ``REQUIREMENTS`` in the `setup.py <https://github.com/divio/djangocms-snippet/blob/master/setup.py>`_
-file for additional dependencies:
-
-|python| |django| |djangocms|
+file for additional dependencies.
 
 
 Installation
@@ -120,11 +118,8 @@ You can run tests by executing::
 
 .. |pypi| image:: https://badge.fury.io/py/djangocms-snippet.svg
     :target: http://badge.fury.io/py/djangocms-snippet
-.. |build| image:: https://travis-ci.org/divio/djangocms-snippet.svg?branch=master
-    :target: https://travis-ci.org/divio/djangocms-snippet
-.. |coverage| image:: https://codecov.io/gh/divio/djangocms-snippet/branch/master/graph/badge.svg
-    :target: https://codecov.io/gh/divio/djangocms-snippet
-
+.. |coverage| image:: https://codecov.io/gh/django-cms/djangocms-snippet/branch/master/graph/badge.svg
+    :target: https://codecov.io/gh/django-cms/djangocms-snippet
 .. |python| image:: https://img.shields.io/badge/python-3.5+-blue.svg
     :target: https://pypi.org/project/djangocms-snippet/
 .. |django| image:: https://img.shields.io/badge/django-2.2,%203.0,%203.1-blue.svg


### PR DESCRIPTION
## Description

I've moved badges to the top of the readme. I think that's where people expect them & it stops me missing them again!! I've also removed the travis badge.

I'd love to include github workflow badges, but I'm not sure the SVGs they provide work in rst files - at least they didn't in my pycharm preview.

## Checklist

* [x] I have opened this pull request against ``master``
* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
