### PR TITLE
Release 4.0.1.dev1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,10 @@ Changelog
 Unreleased
 ==========
 
+
+4.0.1.dev1 (2022-05-10)
+=======================
+
 * Python 3.8, 3.9 support added
 * Django 3.0, 3.1 and 3.2 support added
 * Python 3.5 and 3.6 support removed

--- a/djangocms_snippet/__init__.py
+++ b/djangocms_snippet/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '4.0.0.dev4'
+__version__ = '4.0.1.dev1'
 
 default_app_config = 'djangocms_snippet.apps.SnippetConfig'


### PR DESCRIPTION
A django-cms 4.0.x only compatible release, contains the following changes:

* Python 3.8, 3.9 support added
* Django 3.0, 3.1 and 3.2 support added
* Python 3.5 and 3.6 support removed
* Django 1.11 support removed
* port-feat: pre-commit config added from the v3 workstream
* fix: Added test coverage to admin preview view