### PR TITLE
Update to ace 1.9.6, load ace editor from static files if djangocms_static_ace is installed, add dark mode

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ Changelog
 unreleased
 ==========
 
+* Add support for ace editor loaded from static files through djangocms-static-ace
+* Add dark mode support
 
 3.0.0 (2020-09-02)
 ==================

--- a/README.rst
+++ b/README.rst
@@ -62,6 +62,11 @@ For a manual install:
 * add ``djangocms_snippet`` to your ``INSTALLED_APPS``
 * run ``python manage.py migrate djangocms_snippet``
 
+Djangocms-snippet uses the ace code editor which normally is loaded from a CDN.
+If you prefer your application to provide the editor locally, you can change
+the requirement from `djangocms_snippet` to `djangocms_snippet[static-ace]` and
+add `djangocms_static_ace` to your project's `INSTALLED_APPS`.
+
 
 Configuration
 -------------

--- a/djangocms_snippet/admin.py
+++ b/djangocms_snippet/admin.py
@@ -7,6 +7,13 @@ from .models import Snippet
 
 
 class SnippetAdmin(admin.ModelAdmin):
+    class Media:
+        js = (
+            "admin/vendor/ace/ace.js"
+            if "djangocms_static_ace" in settings.INSTALLED_APPS
+            else "https://cdnjs.cloudflare.com/ajax/libs/ace/1.9.6/ace.js",
+        )
+
     list_display = ('slug', 'name')
     search_fields = ['slug', 'name']
     prepopulated_fields = {'slug': ('name',)}

--- a/djangocms_snippet/cms_plugins.py
+++ b/djangocms_snippet/cms_plugins.py
@@ -7,6 +7,7 @@ from django.utils.translation import gettext_lazy as _
 from cms.plugin_base import CMSPluginBase
 from cms.plugin_pool import plugin_pool
 
+from .forms import SnippetPluginForm
 from .models import SnippetPtr
 
 

--- a/djangocms_snippet/cms_plugins.py
+++ b/djangocms_snippet/cms_plugins.py
@@ -7,7 +7,6 @@ from django.utils.translation import gettext_lazy as _
 from cms.plugin_base import CMSPluginBase
 from cms.plugin_pool import plugin_pool
 
-from .forms import SnippetPluginForm
 from .models import SnippetPtr
 
 

--- a/djangocms_snippet/templates/djangocms_snippet/admin/change_form.html
+++ b/djangocms_snippet/templates/djangocms_snippet/admin/change_form.html
@@ -3,8 +3,6 @@
 
 {% block object-tools %}
 {{ block.super }}
-
-<script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.2.5/ace.js"></script>
 <script>
 django.jQuery(function () {
     // ace editor cannot be attached directly to a textarea
@@ -19,14 +17,29 @@ django.jQuery(function () {
 
     // init editor with settings
     var editor = ace.edit(div[0]);
-    editor.setTheme('ace/theme/' + settings.theme);
+    var darkMode;
+    if (window.CMS) {
+        if (CMS.API.Helpers.getColorScheme) {
+            darkMode = CMS.API.Helpers.getColorScheme() === 'dark';
+        } else {
+            // django CMS pre-3.11.1
+            darkMode = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+        }
+    } else if (window.localStorage) {
+        // CMS not loaded: set color scheme for admin site / popup window according to settings
+        darkMode = JSON.parse(localStorage.getItem('cms_cookie') || '{}').color_scheme === 'dark';
+    }
+    if (darkMode) {
+        editor.setTheme('ace/theme/tomorrow_night');
+    }  else {
+        editor.setTheme(settings.theme ? 'ace/theme/' + settings.theme : 'ace/theme/github');
+    }
     editor.getSession().setValue(textarea.val());
     editor.getSession().setMode('ace/mode/' + settings.mode);
     editor.setOptions({
         fontSize: '14px',
         cursorStyle: 'smooth'
     });
-    editor.renderer.setScrollMargin(5, 5);
 
     // send data back to textarea when submitting
     textarea.closest('form').submit(function () {

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,10 @@ REQUIREMENTS = [
     'django-treebeard>=4.3,<4.5',
 ]
 
+EXTRA_REQUIREMENTS = {
+    'static-ace': ['djangocms-static-ace', ],
+}
+
 
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',
@@ -57,6 +61,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=REQUIREMENTS,
+    extras_require=EXTRA_REQUIREMENTS,
     classifiers=CLASSIFIERS,
     test_suite='tests.settings.run',
 )


### PR DESCRIPTION

## Description

This PR does

* Update the ace editor used to the (currently) latest version 1.9.6
* Adds dark mode detection (django CMS 3.11+)
* Loads the ace editor files not from cdn but from static files *if* `djangocms_static_ace` is installed 

This fixes the corresponding bug mentioned here https://github.com/django-cms/djangocms-frontend/issues/48

## Related resources

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``master``
* [ ] I have added or modified the tests when changing logic (n/a)
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
