### PR TITLE
ci: Update pypi action branch names

### DIFF
--- a/.github/workflows/publish-to-live-pypi.yml
+++ b/.github/workflows/publish-to-live-pypi.yml
@@ -31,9 +31,9 @@ jobs:
         --outdir dist/
         .
 
-    - name: Publish distribution 📦 to PyPI
+    - name: PyPI - Publish distribution 📦
       if: startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build-n-publish:
-    name: Build and publish Python 🐍 distributions 📦 to TestPyPI
+    name: TestPyPI - Build and publish Python 🐍 distributions 📦
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
@@ -32,7 +32,7 @@ jobs:
         .
 
     - name: Publish distribution 📦 to Test PyPI
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}


### PR DESCRIPTION
The master branch for pypi actions has been sunset so it can't be used anymore, this moves on to `release/v1`