### PR TITLE
feat: enable add button on the SnippetPluginForm

### DIFF
--- a/djangocms_snippet/cms_plugins.py
+++ b/djangocms_snippet/cms_plugins.py
@@ -7,6 +7,7 @@ from django.utils.translation import gettext_lazy as _
 from cms.plugin_base import CMSPluginBase
 from cms.plugin_pool import plugin_pool
 
+from .forms import SnippetPluginForm
 from .models import SnippetPtr
 from .utils import show_draft_content
 
@@ -21,6 +22,7 @@ class SnippetPlugin(CMSPluginBase):
     text_enabled = True
     text_editor_preview = False
     cache = CACHE_ENABLED
+    form = SnippetPluginForm
 
     def render(self, context, instance, placeholder):
         snippet = instance.snippet_grouper.snippet(show_editable=show_draft_content(context["request"]))


### PR DESCRIPTION
Allows creation of a new Snippet when adding a snippet plugin to a page

## Description

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``master``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
