### PR TITLE
Release 4.0.1.dev2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,10 @@ Changelog
 
 Unreleased
 ==========
-* feat: Enable add button to crate a snippet when adding a SnippetPlugin
+
+4.0.1.dev2 (2022-11-15)
+=======================
+* feat: Enable add button to create a snippet when adding a SnippetPlugin
 
 4.0.1.dev1 (2022-05-10)
 =======================

--- a/djangocms_snippet/__init__.py
+++ b/djangocms_snippet/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '4.0.1.dev1'
+__version__ = '4.0.1.dev2'
 
 default_app_config = 'djangocms_snippet.apps.SnippetConfig'


### PR DESCRIPTION
A django-cms 4.0.x only compatible release, contains the following changes:

* feat: Enable add button to create a snippet when adding a SnippetPlugin
