### PR TITLE
Revert "Bump actions/upload-artifact from 3 to 4"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
       run: tox run -f py$(echo ${{ matrix.python-version }} | tr -d .)
 
     - name: Upload coverage data
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: coverage-data
         path: '.coverage.*'
@@ -71,7 +71,7 @@ jobs:
 
       - name: Upload HTML report
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: html-report
           path: htmlcov

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,7 @@ known_django = django
 [testenv]
 commands =
     {envpython} --version
-    {env:COMMAND:coverage} run setup.py test
+    {env:COMMAND:coverage} run tests/settings.py
 deps =
     dj32: Django>=3.2,<4.0
     dj42: Django>=4.2,<5.0


### PR DESCRIPTION
Reverts django-cms/djangocms-snippet#147

## Summary by Sourcery

CI:
- Revert the GitHub Actions workflow to use actions/upload-artifact version 3 instead of version 4.