### PR TITLE
fix: Editing of existing snippet not allowed (unversioned snippets)

### DIFF
--- a/src/djangocms_snippet/forms.py
+++ b/src/djangocms_snippet/forms.py
@@ -5,10 +5,6 @@ from django.db import transaction
 from django.utils.translation import gettext_lazy as _
 
 from djangocms_snippet.models import Snippet, SnippetGrouper, SnippetPtr
-from djangocms_snippet.utils import (
-    djangocms_versioning_enabled,
-    is_versioning_installed,
-)
 
 
 class SnippetForm(forms.ModelForm):

--- a/src/djangocms_snippet/forms.py
+++ b/src/djangocms_snippet/forms.py
@@ -34,10 +34,7 @@ class SnippetForm(forms.ModelForm):
         name = data.get("name")
         slug = data.get("slug")
         snippet_grouper = data.get("snippet_grouper")
-        snippet_queryset = Snippet.objects.all()
-
-        if djangocms_versioning_enabled and is_versioning_installed and snippet_grouper:
-            snippet_queryset = snippet_queryset.exclude(snippet_grouper=snippet_grouper)
+        snippet_queryset = Snippet.objects.exclude(snippet_grouper=snippet_grouper)
 
         for snippet in snippet_queryset:
             if snippet.name == name:


### PR DESCRIPTION
## Description

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->
Fix for #176 

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #176 
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``master``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #pr-review on
[Discord](https://discord-pr-review-channel.django-cms.org/) to find a “pr review buddy” who is
  going to review my pull request.

## Summary by Sourcery

Bug Fixes:
- Fix incorrect filtering of snippets when editing.