### PR TITLE
Fix data migration for already updated 5.0.0 package in djangoCMS 3.11 installations

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -121,6 +121,14 @@ Known Issues
 
 When adding a snippet with the `object` or `embed` tag as root element, the CMS toolbar crashes, making any further editing of the page difficult or impossible. A workaround is to just put those elements inside a `div` tag.
 
+**Versioning for djangocms-snippet installations that migrated to version 5.0.0 on django CMS 3.11**
+
+If you are upgrading from a django CMS 3.11 installation to django CMS 4.1 or later, please be aware of the following:
+
+While `djangocms-snippet` includes a migration (``0010_cms4_grouper_version_data_migration``) designed to create initial versions for existing snippets when `djangocms_versioning` is enabled, this migration may not retroactively apply versioning to snippets that existed in a django CMS 3.11 environment if you already migrated to `djangocms-snippet` version 5.0.0.
+Therefore, if you are upgrading from a django CMS 3.11 with `djangocms_snippet` already at version 5.0.0, you will currently not be able to enable versioning for your snippets.
+This might be fixed in a future release.
+
 
 Running Tests
 -------------

--- a/src/djangocms_snippet/migrations/0010_cms4_grouper_version_data_migration.py
+++ b/src/djangocms_snippet/migrations/0010_cms4_grouper_version_data_migration.py
@@ -57,7 +57,7 @@ class Migration(migrations.Migration):
         ('djangocms_snippet', '0009_auto_20210915_0445'),
     ]
 
-    if djangocms_versioning_installed:
+    if djangocms_versioning_installed and djangocms_versioning_config_enabled:
         dependencies += [('djangocms_versioning', '0015_version_modified'), ]
 
     operations = [


### PR DESCRIPTION
## Description

The content of this fix was done by @ms-18 

The `0010_cms4_grouper_version_data_migration` migration caused errors when the installation of version `5.0.0` was already performed on djangoCMS `3.11`. In that case the migration state was inconsistent as the check in `https://github.com/django-cms/djangocms-snippet/blob/master/src/djangocms_snippet/migrations/0010_cms4_grouper_version_data_migration.py:60` is missing the additional check if the config bool is set.

## Related resources
–

## Checklist
* [ x ] I have opened this pull request against ``master``
* [ x ] I have added or modified the tests when changing logic
* [ x ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ x ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #pr-review on
[Discord](https://discord-pr-review-channel.django-cms.org/) to find a “pr review buddy” who is
  going to review my pull request.

## Summary by Sourcery

Bug Fixes:
- Add a configuration-enabled check alongside the versioning installation guard in the 0010 migration to avoid inconsistent migration states