### PR TITLE
Add `BigAutoField` to `id` fields

### DIFF
--- a/src/djangocms_snippet/models.py
+++ b/src/djangocms_snippet/models.py
@@ -30,6 +30,8 @@ class SnippetGrouper(models.Model):
     The Grouper model for snippet, this is required for versioning
     """
 
+    id = models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")
+
     def __str__(self):
         return self.name
 
@@ -58,6 +60,8 @@ class Snippet(models.Model):
     """
     A snippet of HTML or a Django template
     """
+
+    id = models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")
 
     name = models.CharField(
         verbose_name=_("Name"),


### PR DESCRIPTION
## Description

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

My project has a test to look for unrun migrations. After upgrading DjangoCMS-snippets, it fails with the models being out of sync with the migrations. So this PR simply adds:
*`BigAutoField` to `id` fields on `SnippetGrouper` and `Snippet`

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``master``
* [n/a] I have added or modified the tests when changing logic
* [n/a] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog  -- `I will leave this up to the repo authors.`
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #pr-review on
[Discord](https://discord-pr-review-channel.django-cms.org/) to find a “pr review buddy” who is
  going to review my pull request.
